### PR TITLE
27_collisions.py doesn't stop robot immediately when collision is detected

### DIFF
--- a/examples/python/27_collisions.py
+++ b/examples/python/27_collisions.py
@@ -66,13 +66,19 @@ def main(address, model, power, servo):
     stop_requested = False
     robot.start_state_update(callback, rate=50)
 
-    rv = movej(robot, right_arm=RIGHT_ARM_TARGET, minimum_time=5.0)
+    move_thread = threading.Thread(
+        target=movej, args=(robot,), kwargs={"right_arm": RIGHT_ARM_TARGET, "minimum_time": 5.0}
+    )
+    move_thread.start()
 
-    while not stop_requested:
+    while move_thread.is_alive() and not stop_requested:
         time.sleep(0.01)
 
-    
-    robot.cancel_control()
+    if stop_requested:
+        print("Stopping motion due to collision.")
+        robot.cancel_control()
+
+    move_thread.join()
     robot.stop_state_update()
 
 


### PR DESCRIPTION
1. Currently, ```movej(...)``` blocks: it does not return until the robot finishes the commanded motion.
2. The callback sets ```stop_requested = True```, but the action keeps going.
3. After the fix, ```movej``` runs on its own thread.

As-is:
```
nearest collision distance: 0.0368 | link_right_arm_5 <-> link_torso_2
nearest collision distance: 0.0352 | link_right_arm_5 <-> link_torso_2
nearest collision distance: 0.0335 | link_right_arm_5 <-> link_torso_2
nearest collision distance: 0.0319 | link_right_arm_5 <-> link_torso_2
nearest collision distance: 0.0302 | link_right_arm_5 <-> link_torso_2
nearest collision distance: 0.0286 | link_right_arm_5 <-> link_torso_2      ###Collision Detected###
[...]
nearest collision distance: -0.0039 | link_right_arm_5 <-> link_torso_2     ###Collision Detected###
```

To-be:
```
nearest collision distance: 0.0306 | link_right_arm_5 <-> link_torso_2
nearest collision distance: 0.0289 | link_right_arm_5 <-> link_torso_2
Collision Detected
Stopping motion due to collision.
```